### PR TITLE
include view templates in builds

### DIFF
--- a/gojang/admin/admin_renderer.go
+++ b/gojang/admin/admin_renderer.go
@@ -1,11 +1,11 @@
 package admin
 
 import (
+	"embed"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net/http"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -18,6 +18,9 @@ import (
 
 	"github.com/justinas/nosurf"
 )
+
+//go:embed views
+var ViewFiles embed.FS
 
 // TemplateData holds data for admin template rendering
 type TemplateData struct {
@@ -91,28 +94,31 @@ func parseAdminTemplates() (map[string]*template.Template, error) {
 	}
 
 	templates := make(map[string]*template.Template)
-	templateDir := "./gojang/admin/views"
-	basePath := filepath.Join(templateDir, "admin_base.html")
 
-	// Walk the template directory to find all .html files
-	err := filepath.Walk(templateDir, func(path string, info os.FileInfo, err error) error {
+	baseContent, err := ViewFiles.ReadFile("views/admin_base.html")
+	if err != nil {
+		return nil, fmt.Errorf("reading admin_base.html: %w", err)
+	}
+
+	var modelListContent []byte
+	modelListContent, err = ViewFiles.ReadFile("views/model_list.partial.html")
+	if err != nil {
+		utils.Debugf("parseAdminTemplates: model_list.partial.html not found: %v", err)
+	}
+
+	// Walk the embedded template directory to find all .html files
+	err = fs.WalkDir(ViewFiles, "views", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip directories and non-html files
-		if info.IsDir() || !strings.HasSuffix(path, ".html") {
+		if d.IsDir() || !strings.HasSuffix(path, ".html") {
 			return nil
 		}
 
-		// Get relative path from templateDir
-		relPath, err := filepath.Rel(templateDir, path)
-		if err != nil {
-			return err
-		}
-
-		// Normalize path separators to forward slashes for cross-platform compatibility
-		relPath = filepath.ToSlash(relPath)
+		// Get relative path from views directory
+		relPath := strings.TrimPrefix(path, "views/")
 
 		// Skip admin_base.html itself and CSS directory
 		if relPath == "admin_base.html" || strings.Contains(relPath, "css/") {
@@ -125,7 +131,7 @@ func parseAdminTemplates() (map[string]*template.Template, error) {
 		var tmpl *template.Template
 		if isFragment {
 			// Parse fragment standalone
-			content, err := os.ReadFile(path)
+			content, err := ViewFiles.ReadFile(path)
 			if err != nil {
 				return fmt.Errorf("reading admin fragment %s: %w", relPath, err)
 			}
@@ -135,17 +141,25 @@ func parseAdminTemplates() (map[string]*template.Template, error) {
 			}
 		} else {
 			// Parse with admin_base.html
-			files := []string{basePath, path}
+			content, err := ViewFiles.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading admin page %s: %w", relPath, err)
+			}
+
+			tmpl, err = template.New("admin_base.html").Funcs(funcMap).Parse(string(baseContent))
+			if err != nil {
+				return fmt.Errorf("parsing admin_base.html: %w", err)
+			}
 
 			// For model_index.html, also include the partial
-			if relPath == "model_index.html" {
-				partialPath := filepath.Join(templateDir, "model_list.partial.html")
-				if _, err := os.Stat(partialPath); err == nil {
-					files = append(files, partialPath)
+			if relPath == "model_index.html" && len(modelListContent) > 0 {
+				tmpl, err = tmpl.New("model_list.partial.html").Parse(string(modelListContent))
+				if err != nil {
+					return fmt.Errorf("parsing model_list.partial.html: %w", err)
 				}
 			}
 
-			tmpl, err = template.New(filepath.Base(basePath)).Funcs(funcMap).ParseFiles(files...)
+			tmpl, err = tmpl.New(relPath).Parse(string(content))
 			if err != nil {
 				return fmt.Errorf("parsing admin page %s: %w", relPath, err)
 			}

--- a/gojang/admin/admin_renderer_test.go
+++ b/gojang/admin/admin_renderer_test.go
@@ -1,0 +1,24 @@
+package admin
+
+import "testing"
+
+func TestNewAdminRendererLoadsEmbeddedTemplates(t *testing.T) {
+	renderer, err := NewAdminRenderer(false)
+	if err != nil {
+		t.Fatalf("NewAdminRenderer(false) returned error: %v", err)
+	}
+
+	for _, name := range []string{
+		"model_index.html",
+		"model_list.partial.html",
+	} {
+		if renderer.templates[name] == nil {
+			t.Fatalf("expected embedded admin template %q to be loaded", name)
+		}
+	}
+
+	modelIndex := renderer.templates["model_index.html"]
+	if modelIndex.Lookup("model_list.partial.html") == nil {
+		t.Fatal("expected model_index.html to include model_list.partial.html")
+	}
+}

--- a/gojang/cmd/web/main.go
+++ b/gojang/cmd/web/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/gojangframework/gojang/gojang/http/middleware"
 	"github.com/gojangframework/gojang/gojang/http/routes"
 	"github.com/gojangframework/gojang/gojang/models/db"
+	"github.com/gojangframework/gojang/gojang/views"
 	"github.com/gojangframework/gojang/gojang/views/renderers"
 
 	"github.com/go-chi/chi/v5"
@@ -97,11 +99,21 @@ func main() {
 	r.Use(middleware.LoadUser(sessionManager, client)) // Load user from session on all pages
 
 	// Static files (CSS and assets in views/static)
-	fileServer := http.FileServer(http.Dir("./gojang/views/static"))
+	staticFS, err := fs.Sub(views.StaticFiles, "static")
+	if err != nil {
+		utils.Errorf("Failed to create static sub-filesystem: %v", err)
+		os.Exit(1)
+	}
+	fileServer := http.FileServer(http.FS(staticFS))
 	r.Handle("/static/*", http.StripPrefix("/static", fileServer))
 
 	// Admin static files (keep admin assets in admin folder)
-	adminFileServer := http.FileServer(http.Dir("./gojang/admin/views"))
+	adminFS, err := fs.Sub(admin.ViewFiles, "views")
+	if err != nil {
+		utils.Errorf("Failed to create admin static sub-filesystem: %v", err)
+		os.Exit(1)
+	}
+	adminFileServer := http.FileServer(http.FS(adminFS))
 	r.Handle("/admin/static/*", http.StripPrefix("/admin/static", adminFileServer))
 
 	// Well-known files (security.txt, etc.)

--- a/gojang/views/renderers/renderer.go
+++ b/gojang/views/renderers/renderer.go
@@ -3,9 +3,8 @@ package renderers
 import (
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/gojangframework/gojang/gojang/http/middleware"
 	"github.com/gojangframework/gojang/gojang/models"
+	"github.com/gojangframework/gojang/gojang/views"
 
 	"github.com/justinas/nosurf"
 )
@@ -74,28 +74,25 @@ func parseTemplates() (map[string]*template.Template, error) {
 	}
 
 	templates := make(map[string]*template.Template)
-	templateDir := "./gojang/views/templates"
-	basePath := filepath.Join(templateDir, "base.html")
 
-	// Walk the template directory to find all .html files
-	err := filepath.Walk(templateDir, func(path string, info os.FileInfo, err error) error {
+	baseContent, err := views.TemplateFiles.ReadFile("templates/base.html")
+	if err != nil {
+		return nil, fmt.Errorf("reading base.html: %w", err)
+	}
+
+	// Walk the embedded template directory to find all .html files
+	err = fs.WalkDir(views.TemplateFiles, "templates", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
 		// Skip directories and non-html files
-		if info.IsDir() || !strings.HasSuffix(path, ".html") {
+		if d.IsDir() || !strings.HasSuffix(path, ".html") {
 			return nil
 		}
 
-		// Get relative path from templateDir
-		relPath, err := filepath.Rel(templateDir, path)
-		if err != nil {
-			return err
-		}
-
-		// Normalize path separators to forward slashes for cross-platform compatibility
-		relPath = filepath.ToSlash(relPath)
+		// Get relative path from templates directory
+		relPath := strings.TrimPrefix(path, "templates/")
 
 		// Skip base.html itself
 		if relPath == "base.html" {
@@ -108,7 +105,7 @@ func parseTemplates() (map[string]*template.Template, error) {
 		var tmpl *template.Template
 		if isFragment {
 			// Parse fragment standalone
-			content, err := os.ReadFile(path)
+			content, err := views.TemplateFiles.ReadFile(path)
 			if err != nil {
 				return fmt.Errorf("reading fragment %s: %w", relPath, err)
 			}
@@ -118,7 +115,15 @@ func parseTemplates() (map[string]*template.Template, error) {
 			}
 		} else {
 			// Parse with base.html
-			tmpl, err = template.New(filepath.Base(basePath)).Funcs(funcMap).ParseFiles(basePath, path)
+			content, err := views.TemplateFiles.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", relPath, err)
+			}
+			tmpl, err = template.New("base.html").Funcs(funcMap).Parse(string(baseContent))
+			if err != nil {
+				return fmt.Errorf("parsing base.html: %w", err)
+			}
+			tmpl, err = tmpl.New(relPath).Parse(string(content))
 			if err != nil {
 				return fmt.Errorf("parsing %s: %w", relPath, err)
 			}

--- a/gojang/views/renderers/renderer_test.go
+++ b/gojang/views/renderers/renderer_test.go
@@ -4,6 +4,22 @@ import (
 	"testing"
 )
 
+func TestNewRendererLoadsEmbeddedTemplates(t *testing.T) {
+	renderer, err := NewRenderer(false)
+	if err != nil {
+		t.Fatalf("NewRenderer(false) returned error: %v", err)
+	}
+
+	for _, name := range []string{
+		"home.html",
+		"posts/list.partial.html",
+	} {
+		if renderer.templates[name] == nil {
+			t.Fatalf("expected embedded template %q to be loaded", name)
+		}
+	}
+}
+
 // Test template function: add
 func TestTemplateFuncAdd(t *testing.T) {
 	add := func(a, b int) int { return a + b }

--- a/gojang/views/templates.go
+++ b/gojang/views/templates.go
@@ -1,0 +1,9 @@
+package views
+
+import "embed"
+
+//go:embed templates
+var TemplateFiles embed.FS
+
+//go:embed static
+var StaticFiles embed.FS


### PR DESCRIPTION
This pull request migrates both the main and admin template and static file loading to use Go's `embed.FS` for embedding files into the binary, replacing all filesystem access with embedded resources. This improves deployment simplicity and reliability, as all required assets are now part of the compiled application. Additionally, tests are added to ensure templates are correctly loaded from the embedded filesystem.

**Template and static file embedding:**

* Added `embed.FS` variables (`TemplateFiles`, `StaticFiles`, and `ViewFiles`) to `gojang/views/templates.go` and `gojang/admin/admin_renderer.go` to embed templates and static files into the binary. [[1]](diffhunk://#diff-4340ca99eda04ae54511385b0050458cd59011d3c0009ff17583972a98890decR1-R9) [[2]](diffhunk://#diff-33d109a5405d2734c008ea065386297b30264268c852928ffe0cb5203f58b99eR22-R24)
* Refactored template loading in `gojang/views/renderers/renderer.go` and `gojang/admin/admin_renderer.go` to read from embedded files instead of disk, using `fs.WalkDir` and `ReadFile`. [[1]](diffhunk://#diff-e54bd401e428f96c69a7deea6e275081c52f2d4d489eb231235bbeb2837982eeL77-R95) [[2]](diffhunk://#diff-e54bd401e428f96c69a7deea6e275081c52f2d4d489eb231235bbeb2837982eeL111-R108) [[3]](diffhunk://#diff-e54bd401e428f96c69a7deea6e275081c52f2d4d489eb231235bbeb2837982eeL121-R126) [[4]](diffhunk://#diff-33d109a5405d2734c008ea065386297b30264268c852928ffe0cb5203f58b99eL94-R121) [[5]](diffhunk://#diff-33d109a5405d2734c008ea065386297b30264268c852928ffe0cb5203f58b99eL128-R134) [[6]](diffhunk://#diff-33d109a5405d2734c008ea065386297b30264268c852928ffe0cb5203f58b99eL138-R162)
* Updated static file serving in `gojang/cmd/web/main.go` to use embedded filesystems for both main and admin static assets, replacing `http.Dir` with `http.FS`.

**Testing:**

* Added tests to `gojang/views/renderers/renderer_test.go` and `gojang/admin/admin_renderer_test.go` to verify that templates are loaded from the embedded filesystem and that partials are included as expected. [[1]](diffhunk://#diff-15947f24c64cd6f2c818c1b51f2ae1b95b1ef8f7084d194f733af2219d76facaR7-R22) [[2]](diffhunk://#diff-fb73a2e3e03eb920c43f3fa41c81112ad46b28099ee83a490a7f4d6f4c2fb178R1-R24)

**Code cleanup:**

* Removed unused imports and code related to direct filesystem access (`os`, `filepath`) in renderer files. [[1]](diffhunk://#diff-33d109a5405d2734c008ea065386297b30264268c852928ffe0cb5203f58b99eR4-L8) [[2]](diffhunk://#diff-e54bd401e428f96c69a7deea6e275081c52f2d4d489eb231235bbeb2837982eeR6-R15)

These changes make the application fully self-contained with respect to templates and static assets, improving portability and reducing deployment errors.