### PR TITLE
csp-options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ DEBUG=true
 PORT=8080
 ALLOWED_HOSTS=localhost,127.0.0.1
 
+# Content Security Policy (comma-separated directive values; leave blank for defaults)
+# CSP_SCRIPT_SRC='self','unsafe-inline',https://unpkg.com
+# CSP_CONNECT_SRC='self'
+# CSP_SAME_ORIGIN_FRAME_PATHS=/embed/
+
 # SMTP (for password reset emails)
 SMTP_HOST=smtp.mailtrap.io
 SMTP_PORT=587

--- a/gojang/config/config.go
+++ b/gojang/config/config.go
@@ -15,6 +15,16 @@ type Config struct {
 	Port         string   `env:"PORT" envDefault:"8080"`
 	AllowedHosts []string `env:"ALLOWED_HOSTS" envSeparator:","`
 
+	// Content Security Policy settings. Leave empty to use framework defaults.
+	CSPDefaultSrc               []string `env:"CSP_DEFAULT_SRC" envSeparator:","`
+	CSPScriptSrc                []string `env:"CSP_SCRIPT_SRC" envSeparator:","`
+	CSPStyleSrc                 []string `env:"CSP_STYLE_SRC" envSeparator:","`
+	CSPImgSrc                   []string `env:"CSP_IMG_SRC" envSeparator:","`
+	CSPFontSrc                  []string `env:"CSP_FONT_SRC" envSeparator:","`
+	CSPConnectSrc               []string `env:"CSP_CONNECT_SRC" envSeparator:","`
+	CSPFrameAncestors           []string `env:"CSP_FRAME_ANCESTORS" envSeparator:","`
+	CSPSameOriginFrameAncestors []string `env:"CSP_SAME_ORIGIN_FRAME_PATHS" envSeparator:","`
+
 	// Session settings
 	SessionLifetime time.Duration `env:"SESSION_LIFETIME" envDefault:"12h"`
 

--- a/gojang/http/middleware/security.go
+++ b/gojang/http/middleware/security.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gojangframework/gojang/gojang/config"
 )
@@ -24,20 +25,56 @@ func EnforceHTTPS(cfg *config.Config) func(http.Handler) http.Handler {
 
 // SecurityHeaders adds security-related HTTP headers
 func SecurityHeaders(cfg *config.Config) func(http.Handler) http.Handler {
+	return SecurityHeadersWithOptions(SecurityOptionsFromConfig(cfg))
+}
+
+// SecurityOptions configures security-related HTTP headers.
+type SecurityOptions struct {
+	Debug                        bool
+	DefaultSrc                   []string
+	ScriptSrc                    []string
+	StyleSrc                     []string
+	ImgSrc                       []string
+	FontSrc                      []string
+	ConnectSrc                   []string
+	FrameAncestors               []string
+	SameOriginFrameAncestorPaths []string
+}
+
+// SecurityOptionsFromConfig converts application config into middleware options.
+func SecurityOptionsFromConfig(cfg *config.Config) SecurityOptions {
+	if cfg == nil {
+		return defaultSecurityOptions()
+	}
+
+	opts := defaultSecurityOptions()
+	opts.Debug = cfg.Debug
+	opts.DefaultSrc = overrideOrDefault(cfg.CSPDefaultSrc, opts.DefaultSrc)
+	opts.ScriptSrc = overrideOrDefault(cfg.CSPScriptSrc, opts.ScriptSrc)
+	opts.StyleSrc = overrideOrDefault(cfg.CSPStyleSrc, opts.StyleSrc)
+	opts.ImgSrc = overrideOrDefault(cfg.CSPImgSrc, opts.ImgSrc)
+	opts.FontSrc = overrideOrDefault(cfg.CSPFontSrc, opts.FontSrc)
+	opts.ConnectSrc = overrideOrDefault(cfg.CSPConnectSrc, opts.ConnectSrc)
+	opts.FrameAncestors = overrideOrDefault(cfg.CSPFrameAncestors, opts.FrameAncestors)
+	opts.SameOriginFrameAncestorPaths = append([]string(nil), cfg.CSPSameOriginFrameAncestors...)
+	return opts
+}
+
+// SecurityHeadersWithOptions adds security-related HTTP headers.
+func SecurityHeadersWithOptions(opts SecurityOptions) func(http.Handler) http.Handler {
+	opts = normalizeSecurityOptions(opts)
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Content Security Policy
-			w.Header().Set("Content-Security-Policy",
-				"default-src 'self'; "+
-					"script-src 'self' 'unsafe-inline' https://unpkg.com; "+
-					"style-src 'self' 'unsafe-inline'; "+
-					"img-src 'self' data: https:; "+
-					"font-src 'self'; "+
-					"connect-src 'self'; "+
-					"frame-ancestors 'none';")
+			frameAncestors := opts.FrameAncestors
+			frameOptions := "DENY"
+			if pathHasPrefix(r.URL.Path, opts.SameOriginFrameAncestorPaths) {
+				frameAncestors = []string{"'self'"}
+				frameOptions = "SAMEORIGIN"
+			}
 
-			// X-Frame-Options
-			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("Content-Security-Policy", buildCSP(opts, frameAncestors))
+			w.Header().Set("X-Frame-Options", frameOptions)
 
 			// X-Content-Type-Options
 			w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -49,11 +86,78 @@ func SecurityHeaders(cfg *config.Config) func(http.Handler) http.Handler {
 			w.Header().Set("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
 
 			// Strict-Transport-Security (HSTS) - only in production
-			if !cfg.Debug {
+			if !opts.Debug {
 				w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 			}
 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func defaultSecurityOptions() SecurityOptions {
+	return SecurityOptions{
+		DefaultSrc:     []string{"'self'"},
+		ScriptSrc:      []string{"'self'", "'unsafe-inline'", "https://unpkg.com"},
+		StyleSrc:       []string{"'self'", "'unsafe-inline'"},
+		ImgSrc:         []string{"'self'", "data:", "https:"},
+		FontSrc:        []string{"'self'"},
+		ConnectSrc:     []string{"'self'"},
+		FrameAncestors: []string{"'none'"},
+	}
+}
+
+func normalizeSecurityOptions(opts SecurityOptions) SecurityOptions {
+	defaults := defaultSecurityOptions()
+	opts.DefaultSrc = overrideOrDefault(opts.DefaultSrc, defaults.DefaultSrc)
+	opts.ScriptSrc = overrideOrDefault(opts.ScriptSrc, defaults.ScriptSrc)
+	opts.StyleSrc = overrideOrDefault(opts.StyleSrc, defaults.StyleSrc)
+	opts.ImgSrc = overrideOrDefault(opts.ImgSrc, defaults.ImgSrc)
+	opts.FontSrc = overrideOrDefault(opts.FontSrc, defaults.FontSrc)
+	opts.ConnectSrc = overrideOrDefault(opts.ConnectSrc, defaults.ConnectSrc)
+	opts.FrameAncestors = overrideOrDefault(opts.FrameAncestors, defaults.FrameAncestors)
+	return opts
+}
+
+func overrideOrDefault(values, defaults []string) []string {
+	cleaned := cleanDirectiveValues(values)
+	if len(cleaned) == 0 {
+		return append([]string(nil), defaults...)
+	}
+	return cleaned
+}
+
+func cleanDirectiveValues(values []string) []string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			cleaned = append(cleaned, value)
+		}
+	}
+	return cleaned
+}
+
+func buildCSP(opts SecurityOptions, frameAncestors []string) string {
+	directives := []string{
+		"default-src " + strings.Join(opts.DefaultSrc, " "),
+		"script-src " + strings.Join(opts.ScriptSrc, " "),
+		"style-src " + strings.Join(opts.StyleSrc, " "),
+		"img-src " + strings.Join(opts.ImgSrc, " "),
+		"font-src " + strings.Join(opts.FontSrc, " "),
+		"connect-src " + strings.Join(opts.ConnectSrc, " "),
+		"frame-ancestors " + strings.Join(cleanDirectiveValues(frameAncestors), " "),
+	}
+
+	return strings.Join(directives, "; ") + ";"
+}
+
+func pathHasPrefix(path string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		prefix = strings.TrimSpace(prefix)
+		if prefix != "" && strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/gojang/http/middleware/security_test.go
+++ b/gojang/http/middleware/security_test.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gojangframework/gojang/gojang/config"
+)
+
+func TestSecurityHeaders_DefaultCSP(t *testing.T) {
+	handler := SecurityHeadersWithOptions(SecurityOptions{Debug: true})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	for _, want := range []string{
+		"default-src 'self'",
+		"script-src 'self' 'unsafe-inline' https://unpkg.com",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Fatalf("CSP %q does not contain %q", csp, want)
+		}
+	}
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q, want DENY", got)
+	}
+	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Fatalf("Strict-Transport-Security = %q, want empty in debug", got)
+	}
+}
+
+func TestSecurityHeaders_ConfigOverrides(t *testing.T) {
+	cfg := &config.Config{
+		Debug:                       false,
+		CSPScriptSrc:                []string{"'self'", "https://cdn.example.com"},
+		CSPConnectSrc:               []string{"'self'", "https://api.example.com"},
+		CSPSameOriginFrameAncestors: []string{"/embed/"},
+	}
+	handler := SecurityHeaders(cfg)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/regular", nil)
+	handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	for _, want := range []string{
+		"script-src 'self' https://cdn.example.com",
+		"connect-src 'self' https://api.example.com",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Fatalf("CSP %q does not contain %q", csp, want)
+		}
+	}
+	if got := rec.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Fatal("Strict-Transport-Security is empty in production mode")
+	}
+}
+
+func TestSecurityHeaders_SameOriginFramePath(t *testing.T) {
+	handler := SecurityHeadersWithOptions(SecurityOptions{
+		Debug:                        true,
+		SameOriginFrameAncestorPaths: []string{"/embed/"},
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/embed/report", nil)
+	handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "frame-ancestors 'self'") {
+		t.Fatalf("CSP %q does not contain same-origin frame ancestors", csp)
+	}
+	if got := rec.Header().Get("X-Frame-Options"); got != "SAMEORIGIN" {
+		t.Fatalf("X-Frame-Options = %q, want SAMEORIGIN", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add environment-driven CSP settings for `default-src`, `script-src`, `style-src`, `img-src`, `font-src`, `connect-src`, and `frame-ancestors`
- Support path-based same-origin framing for selected routes, including matching `X-Frame-Options` behavior
- Document the new environment variables in `.env.example`
- Add middleware tests covering defaults, overrides, and same-origin embed paths

## Testing
- Added unit tests for default security headers, config overrides, and embed route behavior
- Not run (not requested)