### PR TITLE
Add upload hardening helpers

### DIFF
--- a/gojang/cmd/web/main.go
+++ b/gojang/cmd/web/main.go
@@ -149,11 +149,11 @@ func main() {
 	// Start server
 	addr := fmt.Sprintf(":%s", cfg.Port)
 	srv := &http.Server{
-		Addr:         addr,
-		Handler:      r,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:              addr,
+		Handler:           r,
+		ReadHeaderTimeout: 15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	// Graceful shutdown

--- a/gojang/http/handlers/uploads.go
+++ b/gojang/http/handlers/uploads.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// DefaultMaxUploadBytes is the default maximum multipart request body size.
+const DefaultMaxUploadBytes int64 = 32 << 20
+
+// ParseMultipartFormLimited caps the request body before parsing multipart form
+// data. It returns a MaxUploadSizeError when the request body exceeds maxBytes.
+func ParseMultipartFormLimited(w http.ResponseWriter, r *http.Request, maxBytes int64) error {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxUploadBytes
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	if err := r.ParseMultipartForm(maxBytes); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return &MaxUploadSizeError{Limit: maxBytes}
+		}
+		return err
+	}
+
+	return nil
+}
+
+// MaxUploadSizeError reports that an upload exceeded the configured limit.
+type MaxUploadSizeError struct {
+	Limit int64
+}
+
+func (e *MaxUploadSizeError) Error() string {
+	return fmt.Sprintf("upload exceeds maximum size of %d bytes", e.Limit)
+}
+
+// IsMaxUploadSizeError reports whether err is a MaxUploadSizeError.
+func IsMaxUploadSizeError(err error) bool {
+	var sizeErr *MaxUploadSizeError
+	return errors.As(err, &sizeErr)
+}
+

--- a/gojang/http/handlers/uploads_test.go
+++ b/gojang/http/handlers/uploads_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func multipartRequest(t *testing.T, fieldName, fileName string, fileBytes int) *http.Request {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile(fieldName, fileName)
+	if err != nil {
+		t.Fatalf("CreateFormFile() error = %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("a"), fileBytes)); err != nil {
+		t.Fatalf("part.Write() error = %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/upload", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func TestParseMultipartFormLimited_AllowsRequestUnderLimit(t *testing.T) {
+	req := multipartRequest(t, "file", "small.txt", 128)
+	rec := httptest.NewRecorder()
+
+	if err := ParseMultipartFormLimited(rec, req, 4096); err != nil {
+		t.Fatalf("ParseMultipartFormLimited() error = %v", err)
+	}
+
+	file, header, err := req.FormFile("file")
+	if err != nil {
+		t.Fatalf("FormFile() error = %v", err)
+	}
+	defer file.Close()
+
+	if header.Filename != "small.txt" {
+		t.Fatalf("filename = %q, want %q", header.Filename, "small.txt")
+	}
+}
+
+func TestParseMultipartFormLimited_ReturnsMaxUploadSizeError(t *testing.T) {
+	req := multipartRequest(t, "file", "large.txt", 4096)
+	rec := httptest.NewRecorder()
+
+	err := ParseMultipartFormLimited(rec, req, 512)
+	if err == nil {
+		t.Fatal("ParseMultipartFormLimited() error = nil, want MaxUploadSizeError")
+	}
+	if !IsMaxUploadSizeError(err) {
+		t.Fatalf("IsMaxUploadSizeError() = false for %T: %v", err, err)
+	}
+
+	var sizeErr *MaxUploadSizeError
+	if !errors.As(err, &sizeErr) {
+		t.Fatalf("errors.As(MaxUploadSizeError) = false")
+	}
+	if sizeErr.Limit != 512 {
+		t.Fatalf("Limit = %d, want 512", sizeErr.Limit)
+	}
+}
+


### PR DESCRIPTION
This pull request introduces a new utility for safely handling multipart file uploads by enforcing upload size limits and providing clear error reporting. It also adds comprehensive tests for this functionality. Additionally, there is a minor server configuration update.

**Multipart upload handling improvements:**

* Added `ParseMultipartFormLimited` to `gojang/http/handlers/uploads.go`, which caps multipart upload size and returns a custom `MaxUploadSizeError` if the limit is exceeded. Also includes helper functions and types for error handling (`MaxUploadSizeError`, `IsMaxUploadSizeError`).
* Added unit tests in `gojang/http/handlers/uploads_test.go` to verify that uploads under the limit are accepted and that exceeding the limit triggers the correct error.

**Server configuration:**

* Changed the HTTP server in `gojang/cmd/web/main.go` to use `ReadHeaderTimeout` instead of `ReadTimeout` for more precise timeout control during header parsing.